### PR TITLE
Denial of Service via Empty Plaintext Packet

### DIFF
--- a/golang/go.mod
+++ b/golang/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
     github.com/gin-gonic/gin v1.3.0
     github.com/dgrijalva/jwt-go v3.2.0+incompatible
-    golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+    golang.org/x/crypto v0.0.0-20211202192323-5770296d904e
 )
 


### PR DESCRIPTION
The changes made in the `go.mod` file involve updating the version of the `golang.org/x/crypto` package from `v0.0.0-20201221181555-eec23a3978ad` to `v0.0.0-20211202192323-5770296d904e`. This update addresses a known vulnerability in the older version of the package, which was susceptible to a denial of service attack.

The vulnerability allowed an attacker to cause a panic in the SSH server by sending an empty plaintext packet, potentially leading to service disruption. By updating to a newer version of the `golang.org/x/crypto` package, the application incorporates patches and improvements that mitigate this vulnerability, thus enhancing the security and stability of the application.

This change ensures that the application is protected against the specific attack vector that could exploit the vulnerability in the older version, thereby maintaining the integrity and availability of the service.

Created by: Carlos.cruz@plexicus.com